### PR TITLE
README.md update a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyterlab_table
 
-A JupyterLab and Jupyter Notebook extension for rendering [JSON Table Schema](http://frictionlessdata.io/guides/json-table-schema/)
+A JupyterLab and Jupyter Notebook extension for rendering [JSON Table Schema](http://frictionlessdata.io/guides/table-schema/)
 
 ![output renderer](http://g.recordit.co/X8XNLpKs21.gif)
 


### PR DESCRIPTION
https://frictionlessdata.io/guides/json-table-schema/ now seems to be https://frictionlessdata.io/guides/table-schema/